### PR TITLE
Override can_archived? method in from parent class

### DIFF
--- a/classes/music_album.rb
+++ b/classes/music_album.rb
@@ -7,4 +7,10 @@ class MusicAlbum < Item
     super(published_date, archived)
     @on_spotify = on_spotify
   end
+
+  private
+
+  def can_be_archived?
+    super() && @on_spotify == true
+  end
 end


### PR DESCRIPTION
## In this PR, I did the following:
- Overrode the `can_archived?` method from the parent `Item` class
- returns `true` if parent's method returns `true` AND if `on_spotify` equals `true`
- otherwise, it should return false